### PR TITLE
Added a monster statblock note template

### DIFF
--- a/dnd-5e/assets/note-monster-corner.pdf
+++ b/dnd-5e/assets/note-monster-corner.pdf
@@ -1,0 +1,69 @@
+%PDF-1.5
+%µí®û
+3 0 obj
+<< /Length 4 0 R
+   /Filter /FlateDecode
+>>
+stream
+xœ5ŒÍ
+Â@„ïyŠy×Ùí&ì^½Bõ*D¡ í¡öàë›şHH&™ùÈ$•±Zƒ±©)ùÕŠ5øô8>ˆ~b©ëÙ³¢Ne|İ»x¿åvw—xIF‹	qE‹XĞÄBÅsfÅÁœã®Ûvµ@ÿ;`#ÿ×	tò!…
+endstream
+endobj
+4 0 obj
+   127
+endobj
+2 0 obj
+<<
+   /ExtGState <<
+      /a0 << /CA 1 /ca 1 >>
+   >>
+>>
+endobj
+5 0 obj
+<< /Type /Page
+   /Parent 1 0 R
+   /MediaBox [ 0 0 5.669337 6.520805 ]
+   /Contents 3 0 R
+   /Group <<
+      /Type /Group
+      /S /Transparency
+      /I true
+      /CS /DeviceRGB
+   >>
+   /Resources 2 0 R
+>>
+endobj
+1 0 obj
+<< /Type /Pages
+   /Kids [ 5 0 R ]
+   /Count 1
+>>
+endobj
+6 0 obj
+<< /Creator (cairo 1.15.2 (http://cairographics.org))
+   /Producer (cairo 1.15.2 (http://cairographics.org))
+>>
+endobj
+7 0 obj
+<< /Type /Catalog
+   /Pages 1 0 R
+>>
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000537 00000 n 
+0000000241 00000 n 
+0000000015 00000 n 
+0000000219 00000 n 
+0000000313 00000 n 
+0000000602 00000 n 
+0000000729 00000 n 
+trailer
+<< /Size 8
+   /Root 7 0 R
+   /Info 6 0 R
+>>
+startxref
+781
+%%EOF

--- a/dnd-5e/assets/note-monster-top.pdf
+++ b/dnd-5e/assets/note-monster-top.pdf
@@ -1,0 +1,69 @@
+%PDF-1.5
+%µí®û
+3 0 obj
+<< /Length 4 0 R
+   /Filter /FlateDecode
+>>
+stream
+xœ=LI
+Â@¼Ï+êik¶fæBÀCô(Ä% É!ñà÷íhMÓµuMRé«zP”±†`Àg-1÷Ø]‰şíÖŒ˜‹Ğ+š,ªóOó–9îí¯dkHø˜ÖÚ¾Üùb*qw	Lğ¿h³•Xp×ö„qëÿóaã”Ô|®hÀ	ëÜ’Ç&n
+endstream
+endobj
+4 0 obj
+   137
+endobj
+2 0 obj
+<<
+   /ExtGState <<
+      /a0 << /CA 1 /ca 1 >>
+   >>
+>>
+endobj
+5 0 obj
+<< /Type /Page
+   /Parent 1 0 R
+   /MediaBox [ 0 0 358.016602 6.520802 ]
+   /Contents 3 0 R
+   /Group <<
+      /Type /Group
+      /S /Transparency
+      /I true
+      /CS /DeviceRGB
+   >>
+   /Resources 2 0 R
+>>
+endobj
+1 0 obj
+<< /Type /Pages
+   /Kids [ 5 0 R ]
+   /Count 1
+>>
+endobj
+6 0 obj
+<< /Creator (cairo 1.15.2 (http://cairographics.org))
+   /Producer (cairo 1.15.2 (http://cairographics.org))
+>>
+endobj
+7 0 obj
+<< /Type /Catalog
+   /Pages 1 0 R
+>>
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000549 00000 n 
+0000000251 00000 n 
+0000000015 00000 n 
+0000000229 00000 n 
+0000000323 00000 n 
+0000000614 00000 n 
+0000000741 00000 n 
+trailer
+<< /Size 8
+   /Root 7 0 R
+   /Info 6 0 R
+>>
+startxref
+793
+%%EOF

--- a/dnd-5e/assets/note-monster.svg
+++ b/dnd-5e/assets/note-monster.svg
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="130.3mm"
+   height="2.3mm"
+   viewBox="0 0 130.3 2.3"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="note-monster.svg"
+   inkscape:version="0.92.1 r15371">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="207.37674"
+     inkscape:cy="-22.010912"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1920"
+     inkscape:window-height="1057"
+     inkscape:window-x="-8"
+     inkscape:window-y="691"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true"
+     units="mm"
+     inkscape:snap-page="false"
+     inkscape:snap-others="true"
+     inkscape:snap-nodes="false" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-17.957512,-63.428007)">
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       transform="matrix(0.26458333,0,0,0.26458333,17.957512,63.428007)"
+       id="path4501"
+       d="M 484.91406,0.56640625 H 7.5585938 V 8.1269531 H 484.91406 Z"
+       style="fill:#e69a28;fill-opacity:1;stroke:none;stroke-width:1.13385832;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:#e69a28;fill-opacity:1;stroke:#000000;stroke-width:1.13385832;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 484.91406,8.1269531 h 6.99219 V 0.56640625 h -6.99219"
+       id="path4499"
+       transform="matrix(0.26458333,0,0,0.26458333,17.957512,63.428007)"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#e69a28;fill-opacity:1;stroke:#000000;stroke-width:1.13385832;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 7.5585938,0.56640625 H 0.56640625 V 8.1269531 H 7.5585938"
+       id="path4497"
+       transform="matrix(0.26458333,0,0,0.26458333,17.957512,63.428007)"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.13385832;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 7.5585938,8.1269531 H 484.91406 m 0,-7.56054685 H 7.5585938"
+       id="rect4488"
+       transform="matrix(0.26458333,0,0,0.26458333,17.957512,63.428007)"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+  </g>
+</svg>

--- a/dnd-5e/inc/notes.tex
+++ b/dnd-5e/inc/notes.tex
@@ -18,6 +18,7 @@
 \newlength{\hbNoteRW}
 \newlength{\hbNotePS}
 \newlength{\hbNoteOL}
+\newlength{\hbNoteSBH}
 \newlength{\hbNotePadding}
 \newlength{\hbNoteBoxWidth}
 \newlength{\hbNoteBoxHeight}
@@ -28,7 +29,8 @@
 \setlength{\hbNoteBH}{6pt} % Border height for note
 \setlength{\hbNoteRW}{1pt} % Rule width for note2
 \setlength{\hbNotePS}{3pt} % Point corner for note2
-\setlength{\hbNoteOL}{3pt} % Overlap for title of monster note
+\setlength{\hbNoteOL}{2pt} % Overlap for title of monster note
+\setlength{\hbNoteSBH}{3pt} % Border height for monster note
 \setlength{\hbNotePadding}{2pt} % Horizontal padding inside notes
 
 \newcommand*{\hbNotePrevSubsubsectionStyle}{}
@@ -202,24 +204,24 @@
   \settoheight{\hbNoteBoxHeight}{\usebox{\hbNoteBox}}%
   \settodepth{\hbNoteBoxDepth}{\usebox{\hbNoteBox}}%
   \TPoptions{absolute=false}%
-  \noindent\vspace*{\hbNoteBH}\hspace*{\hbNoteBW}%
-  \begin{textblock*}{\linewidth}(-\hbNoteOL,-\hbNoteBH+1pt)
-    \scalebox{1}[-1]{\includegraphics[width=0.869\hbNoteBH,height=\hbNoteBH]{assets/note-monster-corner}}
+  \noindent\vspace*{\hbNoteSBH}\hspace*{\hbNoteBW}%
+  \begin{textblock*}{\linewidth}(-\hbNoteOL,-\hbNoteSBH+1pt)
+    \scalebox{1}[-1]{\includegraphics[width=0.869\hbNoteSBH,height=\hbNoteSBH]{assets/note-monster-corner}}
   \end{textblock*}%
-  \begin{textblock*}{\linewidth}(\hbNoteOL+\hbNoteBoxWidth-0.869\hbNoteBH,-\hbNoteBH+1pt)
-    \scalebox{-1}[-1]{\includegraphics[width=0.869\hbNoteBH,height=\hbNoteBH]{assets/note-monster-corner}}
+  \begin{textblock*}{\linewidth}(\hbNoteOL+\hbNoteBoxWidth-0.869\hbNoteSBH,-\hbNoteSBH+1pt)
+    \scalebox{-1}[-1]{\includegraphics[width=0.869\hbNoteSBH,height=\hbNoteSBH]{assets/note-monster-corner}}
   \end{textblock*}%
-  \begin{textblock*}{\linewidth}(-\hbNoteOL,\hbNoteBoxHeight+\hbNoteBoxDepth+3pt)
-    \scalebox{1}[1]{\includegraphics[width=0.869\hbNoteBH,height=\hbNoteBH]{assets/note-monster-corner}}
+  \begin{textblock*}{\linewidth}(-\hbNoteOL,\hbNoteBoxHeight+\hbNoteBoxDepth+1pt)
+    \scalebox{1}[1]{\includegraphics[width=0.869\hbNoteSBH,height=\hbNoteSBH]{assets/note-monster-corner}}
   \end{textblock*}%
-  \begin{textblock*}{\linewidth}(\hbNoteOL+\hbNoteBoxWidth-0.869\hbNoteBH,\hbNoteBoxHeight+\hbNoteBoxDepth+3pt)
-    \scalebox{-1}[1]{\includegraphics[width=0.869\hbNoteBH,height=\hbNoteBH]{assets/note-monster-corner}}
+  \begin{textblock*}{\linewidth}(\hbNoteOL+\hbNoteBoxWidth-0.869\hbNoteSBH,\hbNoteBoxHeight+\hbNoteBoxDepth+1pt)
+    \scalebox{-1}[1]{\includegraphics[width=0.869\hbNoteSBH,height=\hbNoteSBH]{assets/note-monster-corner}}
   \end{textblock*}%
-  \begin{textblock*}{\linewidth}(-\hbNoteOL+0.869\hbNoteBH,-\hbNoteBH+1pt)
-    \scalebox{1}[-1]{\includegraphics[width=2\hbNoteOL+\hbNoteBoxWidth-1.739\hbNoteBH,height=\hbNoteBH]{assets/note-monster-top}}
+  \begin{textblock*}{\linewidth}(-\hbNoteOL+0.869\hbNoteSBH,-\hbNoteSBH+1pt)
+    \scalebox{1}[-1]{\includegraphics[width=2\hbNoteOL+\hbNoteBoxWidth-1.739\hbNoteSBH,height=\hbNoteSBH]{assets/note-monster-top}}
   \end{textblock*}%
-  \begin{textblock*}{\linewidth}(-\hbNoteOL+0.869\hbNoteBH,\hbNoteBoxHeight+\hbNoteBoxDepth+3pt)
-    \includegraphics[width=2\hbNoteOL+\hbNoteBoxWidth-1.739\hbNoteBH,height=\hbNoteBH]{assets/note-monster-top}
+  \begin{textblock*}{\linewidth}(-\hbNoteOL+0.869\hbNoteSBH,\hbNoteBoxHeight+\hbNoteBoxDepth+1pt)
+    \includegraphics[width=2\hbNoteOL+\hbNoteBoxWidth-1.739\hbNoteSBH,height=\hbNoteSBH]{assets/note-monster-top}
   \end{textblock*}%
   \begin{textblock*}{\linewidth}(-0.1pt-\hbNoteBW,1pt)
     \includegraphics[width=\hbNoteBW,height=\hbNoteBoxHeight+\hbNoteBoxDepth]{assets/note-side}
@@ -227,7 +229,7 @@
   \begin{textblock*}{\linewidth}(0.1pt+\hbNoteBoxWidth,1pt)
     \reflectbox{\includegraphics[width=\hbNoteBW,height=\hbNoteBoxHeight+\hbNoteBoxDepth]{assets/note-side}}
   \end{textblock*}%
-  \usebox{\hbNoteBox}\vspace*{\hbNoteBH}%
+  \usebox{\hbNoteBox}\vspace*{\hbNoteSBH}%
   \TPoptions{absolute=true}%
 }
 
@@ -266,5 +268,4 @@
 \end{figure*}%
 \hbNoteAfter%
 }
-
 

--- a/dnd-5e/inc/notes.tex
+++ b/dnd-5e/inc/notes.tex
@@ -2,7 +2,7 @@
 %!TEX encoding = UTF-8 Unicode
 
 % Author: Romain "Artefact2" Dal Maso <artefact2@gmail.com>
-% 
+%
 % This program is free software. It comes without any warranty, to the
 % extent permitted by applicable law. You can redistribute it and/or
 % modify it under the terms of the Do What The Fuck You Want To Public
@@ -17,6 +17,7 @@
 \newlength{\hbNoteBH}
 \newlength{\hbNoteRW}
 \newlength{\hbNotePS}
+\newlength{\hbNoteOL}
 \newlength{\hbNotePadding}
 \newlength{\hbNoteBoxWidth}
 \newlength{\hbNoteBoxHeight}
@@ -27,6 +28,7 @@
 \setlength{\hbNoteBH}{6pt} % Border height for note
 \setlength{\hbNoteRW}{1pt} % Rule width for note2
 \setlength{\hbNotePS}{3pt} % Point corner for note2
+\setlength{\hbNoteOL}{3pt} % Overlap for title of monster note
 \setlength{\hbNotePadding}{2pt} % Horizontal padding inside notes
 
 \newcommand*{\hbNotePrevSubsubsectionStyle}{}
@@ -193,3 +195,76 @@
 \end{figure*}%
 \hbNoteAfter%
 }
+
+
+\newcommand*{\hbNoteMonsterDraw}{%
+  \settowidth{\hbNoteBoxWidth}{\usebox{\hbNoteBox}}%
+  \settoheight{\hbNoteBoxHeight}{\usebox{\hbNoteBox}}%
+  \settodepth{\hbNoteBoxDepth}{\usebox{\hbNoteBox}}%
+  \TPoptions{absolute=false}%
+  \noindent\vspace*{\hbNoteBH}\hspace*{\hbNoteBW}%
+  \begin{textblock*}{\linewidth}(-\hbNoteOL,-\hbNoteBH+1pt)
+    \scalebox{1}[-1]{\includegraphics[width=0.869\hbNoteBH,height=\hbNoteBH]{assets/note-monster-corner}}
+  \end{textblock*}%
+  \begin{textblock*}{\linewidth}(\hbNoteOL+\hbNoteBoxWidth-0.869\hbNoteBH,-\hbNoteBH+1pt)
+    \scalebox{-1}[-1]{\includegraphics[width=0.869\hbNoteBH,height=\hbNoteBH]{assets/note-monster-corner}}
+  \end{textblock*}%
+  \begin{textblock*}{\linewidth}(-\hbNoteOL,\hbNoteBoxHeight+\hbNoteBoxDepth+3pt)
+    \scalebox{1}[1]{\includegraphics[width=0.869\hbNoteBH,height=\hbNoteBH]{assets/note-monster-corner}}
+  \end{textblock*}%
+  \begin{textblock*}{\linewidth}(\hbNoteOL+\hbNoteBoxWidth-0.869\hbNoteBH,\hbNoteBoxHeight+\hbNoteBoxDepth+3pt)
+    \scalebox{-1}[1]{\includegraphics[width=0.869\hbNoteBH,height=\hbNoteBH]{assets/note-monster-corner}}
+  \end{textblock*}%
+  \begin{textblock*}{\linewidth}(-\hbNoteOL+0.869\hbNoteBH,-\hbNoteBH+1pt)
+    \scalebox{1}[-1]{\includegraphics[width=2\hbNoteOL+\hbNoteBoxWidth-1.739\hbNoteBH,height=\hbNoteBH]{assets/note-monster-top}}
+  \end{textblock*}%
+  \begin{textblock*}{\linewidth}(-\hbNoteOL+0.869\hbNoteBH,\hbNoteBoxHeight+\hbNoteBoxDepth+3pt)
+    \includegraphics[width=2\hbNoteOL+\hbNoteBoxWidth-1.739\hbNoteBH,height=\hbNoteBH]{assets/note-monster-top}
+  \end{textblock*}%
+  \begin{textblock*}{\linewidth}(-0.1pt-\hbNoteBW,1pt)
+    \includegraphics[width=\hbNoteBW,height=\hbNoteBoxHeight+\hbNoteBoxDepth]{assets/note-side}
+  \end{textblock*}%
+  \begin{textblock*}{\linewidth}(0.1pt+\hbNoteBoxWidth,1pt)
+    \reflectbox{\includegraphics[width=\hbNoteBW,height=\hbNoteBoxHeight+\hbNoteBoxDepth]{assets/note-side}}
+  \end{textblock*}%
+  \usebox{\hbNoteBox}\vspace*{\hbNoteBH}%
+  \TPoptions{absolute=true}%
+}
+
+\NewEnviron{hbMonsterNote}[1][h]{%
+\hbNoteBefore%
+\begin{figure}[#1]%
+  \sbox{\hbNoteBox}{%
+    \colorbox{statblock}{%
+      \hspace*{\hbNotePadding}\begin{minipage}[b]{\linewidth-2\hbNotePadding-2\hbNoteRW-2\fboxsep}%
+        \setlength{\parskip}{\hbNoteCurparskip}%
+        \setlength{\parindent}{\hbNoteCurparindent}%
+        \noindent\scaly\BODY%
+      \end{minipage}%
+      \hspace*{\hbNotePadding}%
+    }%
+  }%
+  \hbNoteMonsterDraw%
+\end{figure}%
+\hbNoteAfter%
+}
+
+\NewEnviron{hbMonsterNoteWide}[1][t]{%
+\hbNoteBefore%
+\begin{figure*}[#1]%
+  \sbox{\hbNoteBox}{%
+    \colorbox{statblock}{%
+      \hspace*{\hbNotePadding}\begin{minipage}[b]{\linewidth-2\hbNotePadding-2\hbNoteRW-2\fboxsep}%
+        \setlength{\parskip}{\hbNoteCurparskip}%
+        \setlength{\parindent}{\hbNoteCurparindent}%
+        \noindent\scaly\BODY%
+      \end{minipage}%
+      \hspace*{\hbNotePadding}%
+    }%
+  }%
+  \hbNoteMonsterDraw%
+\end{figure*}%
+\hbNoteAfter%
+}
+
+

--- a/dnd-5e/inc/root.tex
+++ b/dnd-5e/inc/root.tex
@@ -34,6 +34,7 @@
 \definecolor{subsecrule}{RGB}{211, 169, 98}
 \definecolor{footer}{RGB}{128, 110, 76}
 \definecolor{note}{RGB}{224, 229, 193}
+\definecolor{statblock}{RGB}{253, 241, 220}
 
 \input{inc/fonts}
 \input{inc/sectioning}

--- a/dnd-5e/skel.tex
+++ b/dnd-5e/skel.tex
@@ -78,6 +78,11 @@
 
 \hbLettrine{S}{uspendisse in odio.} \lipsum[110-111]
 
+\begin{hbMonsterNote}
+\subsubsection*{This is a monster statblock note.}
+\noindent\lipsum[16]
+\end{hbMonsterNote}
+
 \lipsum[112-115]
 
 \section*{Libero eget} \lipsum[116-118]


### PR DESCRIPTION
It's based on [statblock5e](https://valloric.github.io/statblock5e/)'s appearance.

Unfortunately, the border gets very badly messed up, just like for the other notes. I tried fixing it with constant offsets, but it seems that the shifted components scale with the height of the note!

For example, the shadow on the side of the regular note and my monster note moves up further the bigger the note contents are. I kind of gave up on fixing it after that... This was tested with miktex on Windows 10.